### PR TITLE
Cleaned up logic in bureau_git_prompt function

### DIFF
--- a/themes/bureau.zsh-theme
+++ b/themes/bureau.zsh-theme
@@ -54,17 +54,16 @@ bureau_git_status () {
 }
 
 bureau_git_prompt () {
-  local _branch=$(bureau_git_branch)
-  local _status=$(bureau_git_status)
-  local _result=""
-  if [[ "${_branch}x" != "x" ]]; then
-    _result="$ZSH_THEME_GIT_PROMPT_PREFIX$_branch"
-    if [[ "${_status}x" != "x" ]]; then
+  if git rev-parse --git-dir > /dev/null 2>&1; then
+    local _branch=$(bureau_git_branch)
+    local _status=$(bureau_git_status)
+    local _result="$ZSH_THEME_GIT_PROMPT_PREFIX$_branch"
+    if [[ -n "$_status" ]]; then
       _result="$_result $_status"
     fi
     _result="$_result$ZSH_THEME_GIT_PROMPT_SUFFIX"
+    echo $_result
   fi
-  echo $_result
 }
 
 


### PR DESCRIPTION
Instead of checking the branch name and running through the bureau_git_status function, it first checks that you're in a git repository.
